### PR TITLE
Corrigir status para parâmetros incorretos

### DIFF
--- a/app/src/java/diario/transferencia/controller/Transfere.java
+++ b/app/src/java/diario/transferencia/controller/Transfere.java
@@ -65,7 +65,7 @@ public class Transfere extends HttpServlet {
 				}
 
 			} catch(ParametrosIncorretosException ex) {
-				response.setStatus(402);
+				response.setStatus(422);
 				excecao = ex;
 			} catch(AlunoInativoException ex) {
 				response.setStatus(400);


### PR DESCRIPTION
# [Grupo 6 | G] Corrigir status para parâmetros incorretos

O código estava como [402](https://developer.mozilla.org/pt-BR/docs/Web/HTTP/Status/402), porém o mais apropriado para o caso de parâmetros incorretos ou ausentes é o [422](https://developer.mozilla.org/pt-BR/docs/Web/HTTP/Status/422).
