### PR TITLE
Corrigindo erro que bugava quando parâmetros eram vazios

### DIFF
--- a/app/src/java/diario/etapas/controller/AtualizarEtapas.java
+++ b/app/src/java/diario/etapas/controller/AtualizarEtapas.java
@@ -108,18 +108,18 @@ public class AtualizarEtapas extends HttpServlet {
 		Map<String, String> dados = new LinkedHashMap<>();
 		boolean temPeloMenosUm = false; // variável que verifica se há um parâmetro além do ID
 
-		if (req.getParameterMap().containsKey("id")) {
+		if (req.getParameterMap().containsKey("id") && !req.getParameter("id").equals("")) {
 			dados.put("id", req.getParameter("id"));
 		} else {
 			return null;
 		}
 
-		if (req.getParameterMap().containsKey("ano")) {
+		if (req.getParameterMap().containsKey("ano") && !req.getParameter("ano").equals("")) {
 			dados.put("ano", req.getParameter("ano"));
 			temPeloMenosUm = true;
 		}
 
-		if (req.getParameterMap().containsKey("valor")) {
+		if (req.getParameterMap().containsKey("valor") && !req.getParameter("valor").equals("")) {
 			dados.put("valor", req.getParameter("valor"));
 			temPeloMenosUm = true;
 		}

--- a/app/src/java/diario/etapas/controller/ConsultarEtapas.java
+++ b/app/src/java/diario/etapas/controller/ConsultarEtapas.java
@@ -98,15 +98,15 @@ public class ConsultarEtapas extends HttpServlet {
 		Map<String, String> dados = new LinkedHashMap<>();
 
 		// definir os valores do map condicionalmente, conforme a requisição
-		if (req.getParameter("id") != null) {
+		if (req.getParameter("id") != null  && !req.getParameter("id").equals("")) {
 			dados.put("id", req.getParameter("id"));
 		}
 
-		if (req.getParameter("ano") != null) {
+		if (req.getParameter("ano") != null  && !req.getParameter("ano").equals("")) {
 			dados.put("ano", req.getParameter("ano"));
 		}
 
-		if (req.getParameter("valor") != null) {
+		if (req.getParameter("valor") != null && !req.getParameter("valor").equals("")) {
 			dados.put("valor", req.getParameter("valor"));
 		}
 

--- a/app/src/java/diario/etapas/controller/InserirEtapas.java
+++ b/app/src/java/diario/etapas/controller/InserirEtapas.java
@@ -89,11 +89,11 @@ public class InserirEtapas extends HttpServlet {
 		Map<String, String> dados = new LinkedHashMap<>();
 
 		// definir os valores do map condicionalmente, conforme a requisição
-		if (req.getParameter("ano") != null) {
+		if (req.getParameter("ano") != null  && !req.getParameter("ano").equals("")) {
 			dados.put("ano", req.getParameter("ano"));
 		}
 
-		if (req.getParameter("valor") != null) {
+		if (req.getParameter("valor") != null  && !req.getParameter("valor").equals("")) {
 			dados.put("valor", req.getParameter("valor"));
 		}
 


### PR DESCRIPTION
# [Grupo 3] Manutenção de etapas

- Servlets de adicionar, consultar e editar bugavam quando algum parâmetro era ""

## Cartões
*Sem cartão*

## Observações
Como foi visto na apresentação de hoje, o formulário bugava quando algum dos parâmetros eram vazios.
