### PR TITLE
Mensagem de falha de autenticação

### DIFF
--- a/app/src/java/diario/transferencia/controller/AutenticacaoException.java
+++ b/app/src/java/diario/transferencia/controller/AutenticacaoException.java
@@ -1,0 +1,13 @@
+package diario.transferencia.controller;
+
+public class AutenticacaoException extends Exception {
+	
+	public AutenticacaoException() {
+		super("Permissão apenas para administrador");
+	}
+
+	public AutenticacaoException(String msg) {
+		super(msg);
+	}
+	
+}

--- a/app/src/java/diario/transferencia/controller/Transfere.java
+++ b/app/src/java/diario/transferencia/controller/Transfere.java
@@ -27,17 +27,17 @@ public class Transfere extends HttpServlet {
 
 		Headers.XMLHeaders(response);
 
-		DiarioAutenticador autenticador = new DiarioAutenticador(request, response);
-		if(autenticador.cargoLogado() != DiarioCargos.ADMIN) {
-			response.setStatus(403);
-			return;
-		}
-
 		try(PrintWriter out = response.getWriter()) {
+			
 			Exception excecao = null;
 			
 			try {
 
+				DiarioAutenticador autenticador = new DiarioAutenticador(request, response);
+				if(autenticador.cargoLogado() != DiarioCargos.ADMIN) {
+					throw new AutenticacaoException();
+				}
+				
 				if(request.getParameter("cpf") == null) {
 					throw new ParametrosIncorretosException("Falha ao receber CPF");
 				}
@@ -64,6 +64,9 @@ public class Transfere extends HttpServlet {
 					throw new ServletException(e);
 				}
 
+			} catch(AutenticacaoException ex) {
+				response.setStatus(403);
+				excecao = ex;
 			} catch(ParametrosIncorretosException ex) {
 				response.setStatus(422);
 				excecao = ex;


### PR DESCRIPTION
# [Grupo 6 | G] Mensagem de falha de autenticação

Quando ocorre uma falha de autenticação, agora é retornada no XML mensagem dizendo que o usuário deve ser administrador.

## Cartões

* [Mensagem de falha de autenticação](https://trello.com/c/1iQ94v6U/67-mensagem-de-falha-de-autentica%C3%A7%C3%A3o)
